### PR TITLE
Better stream parser to handle uncompleted chunks

### DIFF
--- a/src/pricing.js
+++ b/src/pricing.js
@@ -646,8 +646,26 @@ class EntitySpec {
 
         function generateStreamParser(streamChunkHandler)
         {
+            let chunkCache = '';
             return (chunk) => {
-                let msg = JSON.parse(chunk);
+                let msg;
+                let reminder = 0;
+                try {
+                    if (chunkCache.length){
+                        chunk = chunkCache + chunk;
+                    }
+                    if (chunk.indexOf('}{') > -1) {
+                        reminder = chunk.substring(chunk.indexOf('}{')+1, chunk.length);
+                        chunk = chunk.substring(0, chunk.indexOf('}{') + 1)
+                    }
+                    msg = JSON.parse(chunk);
+                    chunkCache = '';
+                    if (reminder) {
+                        chunkCache += reminder;
+                    }
+                } catch (e) {
+                    chunkCache = chunk;
+                }
 
                 if (msg.type == "HEARTBEAT")
                 {

--- a/src/transaction.js
+++ b/src/transaction.js
@@ -8170,8 +8170,26 @@ class EntitySpec {
 
         function generateStreamParser(streamChunkHandler)
         {
+            let chunkCache = '';
             return (chunk) => {
-                let msg = JSON.parse(chunk);
+                let msg;
+                let reminder = 0;
+                try {
+                    if (chunkCache.length){
+                        chunk = chunkCache + chunk;
+                    }
+                    if (chunk.indexOf('}{') > -1) {
+                       reminder = chunk.substring(chunk.indexOf('}{')+1, chunk.length);
+                       chunk = chunk.substring(0, chunk.indexOf('}{') + 1)
+                    }
+                    msg = JSON.parse(chunk);
+                    chunkCache = '';
+                    if (reminder) {
+                        chunkCache += reminder;
+                    }
+                } catch (e) {
+                    chunkCache = chunk;
+                }
 
                 if (msg.type == "HEARTBEAT")
                 {


### PR DESCRIPTION
From time to time it happens that chunk returned from http stream does not contain full JSON string, this parsing it to proper JSON object fails, and ends up with application crash. So i made small modifications to ensure that parsing only happens when full JSON string has arrived, and any leftovers are kept for another turn.

Any comments?